### PR TITLE
Fix logo and android favicon not working on overseerr 1.26.1

### DIFF
--- a/appbox_installer.sh
+++ b/appbox_installer.sh
@@ -972,10 +972,10 @@ EOF
                 sub_filter '\''/api/v1'\'' '\''/$app/api/v1'\'';\
                 sub_filter '\''/login/plex/loading'\'' '\''/$app/login/plex/loading'\'';\
                 sub_filter '\''/images/'\'' '\''/$app/images/'\'';\
-                sub_filter '\''/android-'\'' '\''/$app/android-'\'';\
                 sub_filter '\''/apple-'\'' '\''/$app/apple-'\'';\
                 sub_filter '\''/favicon'\'' '\''/$app/favicon'\'';\
                 sub_filter '\''/logo.png'\'' '\''/$app/logo.png'\'';\
+                sub_filter '\''/logo_full.svg'\'' '\''/$app/logo_full.svg'\'';\
                 sub_filter '\''/site.webmanifest'\'' '\''/$app/site.webmanifest'\'';\
         }' /etc/nginx/sites-enabled/default
     fi

--- a/appbox_installer.sh
+++ b/appbox_installer.sh
@@ -976,6 +976,7 @@ EOF
                 sub_filter '\''/favicon'\'' '\''/$app/favicon'\'';\
                 sub_filter '\''/logo.png'\'' '\''/$app/logo.png'\'';\
                 sub_filter '\''/logo_full.svg'\'' '\''/$app/logo_full.svg'\'';\
+                sub_filter '\''/logo_stacked.svg'\'' '\''/$app/logo_stacked.svg'\'';\
                 sub_filter '\''/site.webmanifest'\'' '\''/$app/site.webmanifest'\'';\
         }' /etc/nginx/sites-enabled/default
     fi


### PR DESCRIPTION
Main logo and icon for Chrome on Android are not showing up in latest Overseerr because of the changes made in the app. This PR will fix these two issues.